### PR TITLE
Cleanups suggested by clang-tidy.

### DIFF
--- a/imu_bno055/include/smbus_functions.h
+++ b/imu_bno055/include/smbus_functions.h
@@ -50,7 +50,7 @@ struct _i2c_rdwr_ioctl_data {
 	int nmsgs;		/* number of i2c_msgs */
 };
 
-static inline __s32 _i2c_smbus_access(int file, char read_write, __u8 command, 
+static inline __s32 _i2c_smbus_access(int file, char read_write, __u8 command,
                                      int size, union _i2c_smbus_data *data)
 {
 	struct _i2c_smbus_ioctl_data args;
@@ -67,7 +67,7 @@ static inline __s32 _i2c_smbus_write_quick(int file, __u8 value)
 {
 	return _i2c_smbus_access(file,value,0,I2C_SMBUS_QUICK,NULL);
 }
-	
+
 static inline __s32 _i2c_smbus_read_byte(int file)
 {
 	union _i2c_smbus_data data;
@@ -93,7 +93,7 @@ static inline __s32 _i2c_smbus_read_byte_data(int file, __u8 command)
 		return 0x0FF & data.byte;
 }
 
-static inline __s32 _i2c_smbus_write_byte_data(int file, __u8 command, 
+static inline __s32 _i2c_smbus_write_byte_data(int file, __u8 command,
                                               __u8 value)
 {
 	union _i2c_smbus_data data;
@@ -112,7 +112,7 @@ static inline __s32 _i2c_smbus_read_word_data(int file, __u8 command)
 		return 0x0FFFF & data.word;
 }
 
-static inline __s32 _i2c_smbus_write_word_data(int file, __u8 command, 
+static inline __s32 _i2c_smbus_write_word_data(int file, __u8 command,
                                               __u16 value)
 {
 	union _i2c_smbus_data data;
@@ -134,7 +134,7 @@ static inline __s32 _i2c_smbus_process_call(int file, __u8 command, __u16 value)
 
 
 /* Returns the number of read bytes */
-static inline __s32 _i2c_smbus_read_block_data(int file, __u8 command, 
+static inline __s32 _i2c_smbus_read_block_data(int file, __u8 command,
                                               __u8 *values)
 {
 	union _i2c_smbus_data data;
@@ -173,7 +173,7 @@ static inline __s32 _i2c_smbus_read_i2c_block_data(int file, __u8 command,
 	}
 }
 
-static inline __s32 _i2c_smbus_write_block_data(int file, __u8 command, 
+static inline __s32 _i2c_smbus_write_block_data(int file, __u8 command,
                                                __u8 length, __u8 *values)
 {
 	union _i2c_smbus_data data;

--- a/imu_bno055/src/bno055_i2c_node.cpp
+++ b/imu_bno055/src/bno055_i2c_node.cpp
@@ -6,18 +6,18 @@
  * working.
  */
 
-#include <imu_bno055/bno055_i2c_activity.h>
+#include <memory>
+
 #include "watchdog/watchdog.h"
-#include <csignal>
+
+#include <imu_bno055/bno055_i2c_activity.h>
 
 int main(int argc, char *argv[]) {
     rclcpp::init(argc, argv);
 
     auto activity = std::make_shared<imu_bno055::BNO055I2CActivity>();
 
-    watchdog::Watchdog* watchdog = NULL;
-
-    watchdog = new watchdog::Watchdog();
+    auto watchdog = std::make_unique<watchdog::Watchdog>();
 
     if(!activity->start()) {
         RCLCPP_ERROR(activity->get_logger(), "Failed to start activity");
@@ -41,8 +41,6 @@ int main(int argc, char *argv[]) {
     watchdog->stop();
 
     rclcpp::shutdown();
-
-    delete watchdog;
 
     return 0;
 }

--- a/imu_bno055/src/watchdog.cpp
+++ b/imu_bno055/src/watchdog.cpp
@@ -1,3 +1,8 @@
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <mutex>
+
 #include "watchdog/watchdog.h"
 
 namespace watchdog {
@@ -21,7 +26,9 @@ Watchdog::~Watchdog() {
 
 void Watchdog::start(unsigned int _interval) {
     std::unique_lock<std::mutex> lock(mutex);
-    if(isRunning) return;
+    if(isRunning) {
+      return;
+    }
 
     lastRefreshTime = std::chrono::steady_clock::now();
     interval = _interval;
@@ -31,7 +38,9 @@ void Watchdog::start(unsigned int _interval) {
 
 void Watchdog::stop() {
     std::unique_lock<std::mutex> lock(mutex);
-    if(!isRunning) return;
+    if(!isRunning) {
+      return;
+    }
 
     isRunning = false;
     stopCondition.notify_all();
@@ -55,6 +64,6 @@ void Watchdog::loop() {
         }
       }
     }
-}  
+}
 
-}  
+}  // namespace watchdog


### PR DESCRIPTION
This is the minimum set of cleanups suggested by clang-tidy:

1.  Remove trailing whitespace
2.  Rearrange includes at the top of files
3.  Replace the Watchdog "new" (which could leak) with a unique_ptr
4.  Add some curly-braces around code blocks
5.  Add closing namespace comments
6.  Add O_CLOEXEC to the open() call

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>