### PR TITLE
Force flushing of stdout.

### DIFF
--- a/imu_bno055/src/bno055_i2c_node.cpp
+++ b/imu_bno055/src/bno055_i2c_node.cpp
@@ -15,6 +15,10 @@
 int main(int argc, char *argv[]) {
     rclcpp::init(argc, argv);
 
+    // Force flush of the stdout buffer, which ensures a sync of all prints
+    // even from a launch file.
+    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
     auto activity = std::make_shared<imu_bno055::BNO055I2CActivity>();
 
     auto watchdog = std::make_unique<watchdog::Watchdog>();


### PR DESCRIPTION
This ensures that we see all messages when running nodes
from a launch file.  This isn't strictly required on Crystal,
but will be required in Dashing.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>